### PR TITLE
Use term.permalink for tag single URL

### DIFF
--- a/templates/tags/list.html
+++ b/templates/tags/list.html
@@ -6,7 +6,7 @@
       <div class="listing-title">{{ trans(key="tags") }}</div>
           {% for term in terms %}
           <li class="tag-list-item">
-              <a class="tagname" href="{{ get_url(path="@/_index.md") }}tags/{{ term.name }}">{{ term.name }}</a>
+              <a class="tagname" href="{{ term.permalink }}">{{ term.name }}</a>
               <span class="tagcount">{{ term.pages | length }}</span>
           </li>
           {% endfor %}


### PR DESCRIPTION
Rather than manually constructing the URL, use the one supplied by Zola. Without this change, tag values must all be lowercase or else the link doesn't work.