### PR TITLE
Fix broken link to tags

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -19,7 +19,7 @@
         {% if page.taxonomies.tags %}
         <i class="fas fa-tags"></i>
         {% for tag in page.taxonomies.tags %}
-        <a class="tag" href="{{ get_url(path=" @/_index.md", lang=lang) }}tags/{{tag}}">&nbsp;{{tag}}</a>
+        <a class="tag" href="{{ get_url(path="@/_index.md", lang=lang) }}tags/{{tag}}">&nbsp;{{tag}}</a>
         {% endfor %}
         {% endif %}
       </div>


### PR DESCRIPTION
When I enabled the `tags` taxonomy I've noticed that the links to the tags below a post are broken. The reason for this is a trailing whitespace before the `@` indicating internal links. I removed the whitespace and the links are now working correctly. This is such a small fix that I didn't bother creating an issue for it, hope that's okay.